### PR TITLE
Check for cycles and return Result when computing topological ordering

### DIFF
--- a/src/Graph.elm
+++ b/src/Graph.elm
@@ -1030,12 +1030,21 @@ heightLevels graph =
 [topological ordering](https://en.wikipedia.org/wiki/Topological_sorting) of the
 given graph.
 -}
-topologicalSort : Graph n e -> List (NodeContext n e)
+topologicalSort : Graph n e -> Result String (List (NodeContext n e))
 topologicalSort graph =
-  graph
-    |> dfsForest (nodeIds graph)
-    |> List.reverse
-    |> List.concatMap Tree.preOrderList
+  let
+    scc = stronglyConnectedComponents graph
+    unwrapSingleNodeGraph g =
+      case List.head (nodeIds g) of
+        Nothing ->
+          Nothing
+        Just nodeId ->
+          get nodeId g
+  in
+    if List.length scc == size graph then
+      Result.Ok (List.filterMap unwrapSingleNodeGraph scc)
+    else
+      Result.Err "Cannot compute topological ordering because the graph contains at least one cycle"
 
 
 {-| Decomposes a graph into its strongly connected components. The resulting

--- a/tests/Tests/Graph.elm
+++ b/tests/Tests/Graph.elm
@@ -16,6 +16,12 @@ isJust m =
     Just _ -> True
     _ -> False
 
+isErr : Result m n -> Bool
+isErr result =
+  case result of
+    Err _ -> True
+    Ok _ -> False
+
 
 expectEqualComparing : (a -> b) -> a  -> a -> Expect.Expectation
 expectEqualComparing f a b =
@@ -57,6 +63,27 @@ dressUp =
       , e 7 8 -- tie before jacket
       ]
 
+  in
+    Graph.fromNodesAndEdges nodes edges
+
+
+dressUpWithCycle : Graph String ()
+dressUpWithCycle =
+  let
+    nodes =
+      [ Node 0 "Socks"
+      , Node 1 "Undershorts"
+      , Node 2 "Pants"
+      ]
+
+    e from to =
+      Edge from to ()
+
+    edges =
+      [ e 0 1
+      , e 1 2
+      , e 2 0
+      ]
   in
     Graph.fromNodesAndEdges nodes edges
 
@@ -284,6 +311,10 @@ all =
               (case Graph.topologicalSort dressUp of
                 Ok ordering -> isValidTopologicalOrderingOf dressUp ordering
                 Err err -> False)
+        , test "returns error for graph with cycles" <| \() ->
+            Expect.true
+              "expected Result.Err"
+              (isErr (Graph.topologicalSort dressUpWithCycle))
         , test "heightLevels" <| \() ->
             Expect.true
               "expected a valid topological ordering"

--- a/tests/Tests/Graph.elm
+++ b/tests/Tests/Graph.elm
@@ -281,9 +281,9 @@ all =
         [ test "topologicalSort" <| \() ->
             Expect.true
               "expected a valid topological ordering"
-              (dressUp
-                |> Graph.topologicalSort
-                |> isValidTopologicalOrderingOf dressUp)
+              (case Graph.topologicalSort dressUp of
+                Ok ordering -> isValidTopologicalOrderingOf dressUp ordering
+                Err err -> False)
         , test "heightLevels" <| \() ->
             Expect.true
               "expected a valid topological ordering"


### PR DESCRIPTION
Fixes #4.

Introduces the changes discussed in #4. I'm not very experienced with Elm, so feedback is welcome.

`topologicalSort` now returns a `Result` with a string in the error case, and otherwise the ordering. If there were more than one type of error, I suppose it may have been cleaner to introduce a union type representing the different errors, but since we only have one error I thought this was the simplest way.