### PR TITLE
Add GraphViz output support

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -8,7 +8,8 @@
     ],
     "exposed-modules": [
         "Graph",
-        "Graph.Tree"
+        "Graph.Tree",
+        "Graph.GraphViz"
     ],
     "dependencies": {
         "avh4/elm-fifo": "1.0.3 <= v < 2.0.0",

--- a/src/Graph/GraphViz.elm
+++ b/src/Graph/GraphViz.elm
@@ -4,6 +4,7 @@ module Graph.GraphViz
         , outputWithStyles
         , defaultStyles
         , Styles
+        , Rankdir(..)
         )
 
 {-| This module provides a means of converting the `Graph` data type into a valid [GraphViz](http://www.graphviz.org/) string for visualizing your graph structure.
@@ -18,7 +19,7 @@ You can also dynamically draw your graph in your application by sending the stri
 
 GraphViz allows for customizing the graph's look via "Attrs."
 
-@docs Styles, defaultStyles, outputWithStyles
+@docs Styles, Rankdir, defaultStyles, outputWithStyles
 -}
 
 import Graph exposing (Graph, Edge, Node, edges, nodes, get)
@@ -36,10 +37,20 @@ output =
 Note that `Styles` is made up of strings, which loses type safety, but allows you to use any GraphViz attrs without having to model them out in entirety in this module.  It is up to you to make sure you provide valid attr strings.  See http://www.graphviz.org/content/attrs for available options.
 -}
 type alias Styles =
-    { graph : String
+    { rankdir : Rankdir
+    , graph : String
     , node : String
     , edge : String
     }
+
+
+{-| Values to control the direction of the graph
+-}
+type Rankdir
+    = TB
+    | LR
+    | BT
+    | RL
 
 
 {-| A blank `Styles` record to build from to define your own styles.
@@ -51,7 +62,7 @@ type alias Styles =
 -}
 defaultStyles : Styles
 defaultStyles =
-    Styles "" "" ""
+    Styles TB "" "" ""
 
 
 {-| Same as `output`, but allows you to add attrs to the graph.  These attrs will be applied to the entire graph.
@@ -99,24 +110,11 @@ outputWithStyles styles graph =
 
         node node =
             "  " ++ Basics.toString node.label
-
-        graphStyles =
-            "  graph [" ++ styles.graph ++ "]"
-
-        nodeStyles =
-            "  node [" ++ styles.node ++ "]"
-
-        edgeStyles =
-            "  edge [" ++ styles.edge ++ "]"
     in
         "digraph G {\n"
-            ++ graphStyles
-            ++ "\n"
-            ++ nodeStyles
-            ++ "\n"
-            ++ edgeStyles
-            ++ "\n\n"
-            ++ edgesString
-            ++ "\n\n"
-            ++ nodesString
-            ++ "\n}"
+            ++ ("  rankdir=" ++ toString styles.rankdir ++ "\n")
+            ++ ("  graph [" ++ styles.graph ++ "]" ++ "\n")
+            ++ ("  node [" ++ styles.node ++ "]" ++ "\n")
+            ++ ("  edge [" ++ styles.edge ++ "]" ++ "\n\n")
+            ++ (edgesString ++ "\n\n")
+            ++ (nodesString ++ "\n}")

--- a/src/Graph/GraphViz.elm
+++ b/src/Graph/GraphViz.elm
@@ -1,14 +1,24 @@
-module Graph.GraphViz exposing (output)
+module Graph.GraphViz
+    exposing
+        ( output
+        , outputWithStyles
+        , defaultStyles
+        , Styles
+        )
 
 {-| This module provides a means of converting the `Graph` data type into a valid [GraphViz](http://www.graphviz.org/) string for visualizing your graph structure.
 
- You can easily preview your graph by inserting the generated string into an online GraphViz tool like https://dreampuf.github.io/GraphvizOnline/.
+You can easily preview your graph by inserting the generated string into an online GraphViz tool like https://dreampuf.github.io/GraphvizOnline/.
 
- You can also dynamically draw your graph in your application by sending the string over a port to the javascript version of the GraphViz library, https://github.com/mdaines/viz.js/ (see the examples there fore more specifics on how to embed the generated visualization).
-
-Note that this currently only supports a subset of the full GraphViz language.
+You can also dynamically draw your graph in your application by sending the string over a port to the javascript version of the GraphViz library, https://github.com/mdaines/viz.js/ (see the examples there fore more specifics on how to embed the generated visualization).
 
 @docs output
+
+# Attrs
+
+GraphViz allows for customizing the graph's look via "Attrs."
+
+@docs Styles, defaultStyles, outputWithStyles
 -}
 
 import Graph exposing (Graph, Edge, Node, edges, nodes, get)
@@ -17,7 +27,37 @@ import Graph exposing (Graph, Edge, Node, edges, nodes, get)
 {-| Converts a `Graph` into a valid GraphViz string.  Note that the you must supply a `Graph String e` type, where the `String` is the label that should be printed in each node.
 -}
 output : Graph String e -> String
-output graph =
+output =
+    outputWithStyles defaultStyles
+
+
+{-| A type representing the attrs to apply at the graph, node, and edge entities (subgraphs and cluster subgraphs are not supported).
+
+Note that `Styles` is made up of strings, which loses type safety, but allows you to use any GraphViz attrs without having to model them out in entirety in this module.  It is up to you to make sure you provide valid attr strings.  See http://www.graphviz.org/content/attrs for available options.
+-}
+type alias Styles =
+    { graph : String
+    , node : String
+    , edge : String
+    }
+
+
+{-| A blank `Styles` record to build from to define your own styles.
+
+    myStyles =
+        { defaultStyles
+            | node = "shape=box, color=blue, style=\"rounded, filled\""
+        }
+-}
+defaultStyles : Styles
+defaultStyles =
+    Styles "" "" ""
+
+
+{-| Same as `output`, but allows you to add attrs to the graph.  These attrs will be applied to the entire graph.
+-}
+outputWithStyles : Styles -> Graph String e -> String
+outputWithStyles styles graph =
     let
         getText id =
             get id graph
@@ -45,7 +85,7 @@ output graph =
 
         edgesString =
             List.map edge edges
-                |> String.join ";\n"
+                |> String.join "\n"
 
         edge ({ from, to, label } as edge) =
             "  "
@@ -55,9 +95,28 @@ output graph =
 
         nodesString =
             List.map node nodes
-                |> String.join ";\n"
+                |> String.join "\n"
 
         node node =
             "  " ++ Basics.toString node.label
+
+        graphStyles =
+            "  graph [" ++ styles.graph ++ "]"
+
+        nodeStyles =
+            "  node [" ++ styles.node ++ "]"
+
+        edgeStyles =
+            "  edge [" ++ styles.edge ++ "]"
     in
-        "digraph G {\n" ++ edgesString ++ ";\n\n" ++ nodesString ++ ";\n}"
+        "digraph G {\n"
+            ++ graphStyles
+            ++ "\n"
+            ++ nodeStyles
+            ++ "\n"
+            ++ edgeStyles
+            ++ "\n\n"
+            ++ edgesString
+            ++ "\n\n"
+            ++ nodesString
+            ++ "\n}"

--- a/src/Graph/GraphViz.elm
+++ b/src/Graph/GraphViz.elm
@@ -1,0 +1,63 @@
+module Graph.GraphViz exposing (output)
+
+{-| This module provides a means of converting the `Graph` data type into a valid [GraphViz](http://www.graphviz.org/) string for visualizing your graph structure.
+
+ You can easily preview your graph by inserting the generated string into an online GraphViz tool like https://dreampuf.github.io/GraphvizOnline/.
+
+ You can also dynamically draw your graph in your application by sending the string over a port to the javascript version of the GraphViz library, https://github.com/mdaines/viz.js/ (see the examples there fore more specifics on how to embed the generated visualization).
+
+Note that this currently only supports a subset of the full GraphViz language.
+
+@docs output
+-}
+
+import Graph exposing (Graph, Edge, Node, edges, nodes, get)
+
+
+{-| Converts a `Graph` into a valid GraphViz string.  Note that the you must supply a `Graph String e` type, where the `String` is the label that should be printed in each node.
+-}
+output : Graph String e -> String
+output graph =
+    let
+        getText id =
+            get id graph
+                |> Maybe.map (.node >> .label)
+                |> Maybe.withDefault ("*Node id " ++ toString id ++ " not found*")
+
+        edges =
+            let
+                sortEdges a b =
+                    case compare a.from b.from of
+                        LT ->
+                            LT
+
+                        GT ->
+                            GT
+
+                        EQ ->
+                            compare a.to b.to
+            in
+                Graph.edges graph
+                    |> List.sortWith sortEdges
+
+        nodes =
+            Graph.nodes graph
+
+        edgesString =
+            List.map edge edges
+                |> String.join ";\n"
+
+        edge ({ from, to, label } as edge) =
+            "  "
+                ++ Basics.toString (getText from)
+                ++ " -> "
+                ++ Basics.toString (getText to)
+
+        nodesString =
+            List.map node nodes
+                |> String.join ";\n"
+
+        node node =
+            "  " ++ Basics.toString node.label
+    in
+        "digraph G {\n" ++ edgesString ++ ";\n\n" ++ nodesString ++ ";\n}"

--- a/tests/Tests/Graph/GraphViz.elm
+++ b/tests/Tests/Graph/GraphViz.elm
@@ -1,0 +1,51 @@
+module Tests.Graph.GraphViz exposing (all)
+
+import Graph.GraphViz as Viz exposing (output)
+import Graph exposing (Graph, NodeId, Node, Edge, NodeContext)
+import Test exposing (..)
+import Expect
+
+
+all : Test
+all =
+    describe "GraphViz"
+        [ describe "output" <|
+            [ test "basic" <|
+                let
+                    nodes =
+                        [ Node 0 "Welcome"
+                        , Node 1 "To"
+                        , Node 2 "Web"
+                        , Node 3 "GraphViz!"
+                        ]
+
+                    e from to =
+                        Edge from to ()
+
+                    edges =
+                        [ e 0 1
+                        , e 1 2
+                        , e 1 3
+                        ]
+
+                    g =
+                        Graph.fromNodesAndEdges nodes edges
+
+                    expected =
+                        """digraph G {
+  "Welcome" -> "To";
+  "To" -> "Web";
+  "To" -> "GraphViz!";
+
+  "Welcome";
+  "To";
+  "Web";
+  "GraphViz!";
+}"""
+
+                    actual =
+                        output g
+                in
+                    \() -> Expect.equal expected actual
+            ]
+        ]

--- a/tests/Tests/Graph/GraphViz.elm
+++ b/tests/Tests/Graph/GraphViz.elm
@@ -33,6 +33,7 @@ all =
 
                     expected =
                         """digraph G {
+  rankdir=TB
   graph []
   node []
   edge []
@@ -74,6 +75,7 @@ all =
 
                     expected =
                         """digraph G {
+  rankdir=LR
   graph [bgcolor=red]
   node [shape=box, color=blue, style="rounded, filled"]
   edge []
@@ -90,7 +92,8 @@ all =
 
                     myStyles =
                         { defaultStyles
-                            | graph = "bgcolor=red"
+                            | rankdir = LR
+                            , graph = "bgcolor=red"
                             , node = "shape=box, color=blue, style=\"rounded, filled\""
                         }
 

--- a/tests/Tests/Graph/GraphViz.elm
+++ b/tests/Tests/Graph/GraphViz.elm
@@ -13,10 +13,10 @@ all =
             [ test "basic" <|
                 let
                     nodes =
-                        [ Node 0 "Welcome"
-                        , Node 1 "To"
-                        , Node 2 "Web"
-                        , Node 3 "GraphViz!"
+                        [ Node 0 { text = "Welcome" }
+                        , Node 1 { text = "To" }
+                        , Node 2 { text = "Web" }
+                        , Node 3 { text = "GraphViz!" }
                         ]
 
                     e from to =
@@ -55,10 +55,10 @@ all =
             , test "with styles" <|
                 let
                     nodes =
-                        [ Node 0 "Welcome"
-                        , Node 1 "To"
-                        , Node 2 "Web"
-                        , Node 3 "GraphViz!"
+                        [ Node 0 { text = "Welcome" }
+                        , Node 1 { text = "To" }
+                        , Node 2 { text = "Web" }
+                        , Node 3 { text = "GraphViz!" }
                         ]
 
                     e from to =
@@ -99,6 +99,56 @@ all =
 
                     actual =
                         outputWithStyles myStyles g
+                in
+                    \() -> Expect.equal expected actual
+            , test "with styles with overrides" <|
+                let
+                    n id text attrs =
+                        Node id { text = text, attrs = attrs, other = "other" }
+
+                    nodes =
+                        [ n 0 "Welcome" ""
+                        , n 1 "To" ""
+                        , n 2 "Web" ""
+                        , n 3 "GraphViz!" "style=\"bold,filled\""
+                        ]
+
+                    e from to attrs =
+                        Edge from to { attrs = attrs, other = "other" }
+
+                    edges =
+                        [ e 0 1 ""
+                        , e 1 2 ""
+                        , e 1 3 "penwidth=5"
+                        ]
+
+                    myStyles =
+                        { defaultStyles
+                            | node = "style=rounded"
+                        }
+
+                    g =
+                        Graph.fromNodesAndEdges nodes edges
+
+                    expected =
+                        """digraph G {
+  rankdir=TB
+  graph []
+  node [style=rounded]
+  edge []
+
+  "Welcome" -> "To"
+  "To" -> "Web"
+  "To" -> "GraphViz!" [penwidth=5]
+
+  "Welcome"
+  "To"
+  "Web"
+  "GraphViz!" [style="bold,filled"]
+}"""
+
+                    actual =
+                        outputWithStylesWithOverrides myStyles g
                 in
                     \() -> Expect.equal expected actual
             ]

--- a/tests/Tests/Graph/GraphViz.elm
+++ b/tests/Tests/Graph/GraphViz.elm
@@ -1,6 +1,6 @@
 module Tests.Graph.GraphViz exposing (all)
 
-import Graph.GraphViz as Viz exposing (output)
+import Graph.GraphViz as Viz exposing (..)
 import Graph exposing (Graph, NodeId, Node, Edge, NodeContext)
 import Test exposing (..)
 import Expect
@@ -33,18 +33,69 @@ all =
 
                     expected =
                         """digraph G {
-  "Welcome" -> "To";
-  "To" -> "Web";
-  "To" -> "GraphViz!";
+  graph []
+  node []
+  edge []
 
-  "Welcome";
-  "To";
-  "Web";
-  "GraphViz!";
+  "Welcome" -> "To"
+  "To" -> "Web"
+  "To" -> "GraphViz!"
+
+  "Welcome"
+  "To"
+  "Web"
+  "GraphViz!"
 }"""
 
                     actual =
                         output g
+                in
+                    \() -> Expect.equal expected actual
+            , test "with styles" <|
+                let
+                    nodes =
+                        [ Node 0 "Welcome"
+                        , Node 1 "To"
+                        , Node 2 "Web"
+                        , Node 3 "GraphViz!"
+                        ]
+
+                    e from to =
+                        Edge from to ()
+
+                    edges =
+                        [ e 0 1
+                        , e 1 2
+                        , e 1 3
+                        ]
+
+                    g =
+                        Graph.fromNodesAndEdges nodes edges
+
+                    expected =
+                        """digraph G {
+  graph [bgcolor=red]
+  node [shape=box, color=blue, style="rounded, filled"]
+  edge []
+
+  "Welcome" -> "To"
+  "To" -> "Web"
+  "To" -> "GraphViz!"
+
+  "Welcome"
+  "To"
+  "Web"
+  "GraphViz!"
+}"""
+
+                    myStyles =
+                        { defaultStyles
+                            | graph = "bgcolor=red"
+                            , node = "shape=box, color=blue, style=\"rounded, filled\""
+                        }
+
+                    actual =
+                        outputWithStyles myStyles g
                 in
                     \() -> Expect.equal expected actual
             ]


### PR DESCRIPTION
This is a great package, but it is missing a way to visualize the graph.  GraphViz (http://www.graphviz.org/) is great for that, so I've added a module to build up a valid GraphViz string from the Graph type (inspired from https://github.com/iosphere/elm-network-graph/blob/2.0.0/src/Graph/GraphViz.elm).