### PR TITLE
Add export to TGF

### DIFF
--- a/src/Graph/TGF.elm
+++ b/src/Graph/TGF.elm
@@ -1,0 +1,42 @@
+module Graph.TGF exposing (output)
+
+{-| This module provides a means of converting the `Graph` data type into a valid [TGF](https://en.wikipedia.org/wiki/Trivial_Graph_Format) string for visualizing your graph structure.
+
+You can preview your graph by inserting the generated string into [yEd](http://www.yworks.com/products/yed) or other compatible software.
+
+
+# Conversion
+
+@docs output
+
+-}
+
+import Graph exposing (Edge, Graph, Node, edges, nodes)
+
+
+{-| Converts a `Graph` into a valid TGF string.
+-}
+output : (node -> String) -> (edge -> String) -> Graph node edge -> String
+output mapNode mapEdge graph =
+    let
+        nodes =
+            Graph.nodes graph
+                |> List.map
+                    (\{ id, label } ->
+                        toString id ++ " " ++ mapNode label
+                    )
+                |> List.sort
+
+        edges =
+            Graph.edges graph
+                |> List.map
+                    (\{ from, to, label } ->
+                        toString from ++ " " ++ toString to ++ " " ++ mapEdge label
+                    )
+                |> List.sort
+    in
+    (nodes ++ [ "#" ] ++ edges)
+        -- trimming is questionable; little info about the format exists.
+        -- yEd imports it fine though.
+        |> List.map String.trim
+        |> String.join "\n"

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -2,6 +2,7 @@ module Tests exposing (suite)
 
 import Test exposing (..)
 import Tests.Graph
+import Tests.Graph.TGF
 import Tests.Graph.Tree
 
 
@@ -10,4 +11,5 @@ suite =
     describe "elm-graph"
         [ Tests.Graph.all
         , Tests.Graph.Tree.all
+        , Tests.Graph.TGF.all
         ]

--- a/tests/Tests/Graph/TGF.elm
+++ b/tests/Tests/Graph/TGF.elm
@@ -1,0 +1,100 @@
+module Tests.Graph.TGF exposing (all)
+
+import Expect
+import Graph exposing (Edge, Node)
+import Graph.TGF exposing (..)
+import Test exposing (..)
+
+
+all : Test
+all =
+    describe "TGF"
+        [ describe "output" <|
+            [ test "without edge labels" <|
+                let
+                    nodes =
+                        [ Node 0 { text = "This" }
+                        , Node 1 { text = "Is" }
+                        , Node 2 { text = "TGF" }
+                        , Node 3 { text = "Trivial" }
+                        , Node 4 { text = "Graph" }
+                        , Node 5 { text = "Format" }
+                        ]
+
+                    e from to =
+                        Edge from to ()
+
+                    edges =
+                        [ e 0 1
+                        , e 1 2
+                        , e 3 2
+                        , e 4 2
+                        , e 5 2
+                        ]
+
+                    g =
+                        Graph.fromNodesAndEdges nodes edges
+
+                    expected =
+                        """0 This
+1 Is
+2 TGF
+3 Trivial
+4 Graph
+5 Format
+#
+0 1
+1 2
+3 2
+4 2
+5 2"""
+
+                    actual =
+                        output .text (always "") g
+                in
+                \() -> Expect.equal expected actual
+            , test "with edge labels" <|
+                let
+                    nodes =
+                        [ Node 0 { text = "This" }
+                        , Node 1 { text = "Is" }
+                        , Node 2 { text = "TGF" }
+                        , Node 3 { text = "Trivial" }
+                        , Node 4 { text = "Graph" }
+                        , Node 5 { text = "Format" }
+                        ]
+
+                    e from to label =
+                        Edge from to { text = label }
+
+                    edges =
+                        [ e 0 1 "a"
+                        , e 1 2 "b"
+                        , e 3 2 "c"
+                        , e 4 2 "d"
+                        , e 5 2 "e"
+                        ]
+
+                    g =
+                        Graph.fromNodesAndEdges nodes edges
+
+                    expected =
+                        """0 This
+1 Is
+2 TGF
+3 Trivial
+4 Graph
+5 Format
+#
+0 1 a
+1 2 b
+3 2 c
+4 2 d
+5 2 e"""
+
+                    actual =
+                        output .text .text g
+                in
+                \() -> Expect.equal expected actual
+            ]
+        ]


### PR DESCRIPTION
This would be useful ie. in https://github.com/jhrcek/graph-editor

One possible thing: the API could be made nicer by having a function that doesn't require (and discards) edge labels. In this way the users wouldn't have to have a `{ edge | text : String }` type for their edges, and possibly unnecessary `{ text = "" }` edge values. What do you think?

Edit: by the way, is there a reason the `Tests.Graph.GraphViz` tests aren't included in the test suite, but exist in the filesystem?