### PR TITLE
Fix DOT export for empty/edgeless graphs

### DIFF
--- a/src/Graph/DOT.elm
+++ b/src/Graph/DOT.elm
@@ -156,7 +156,7 @@ outputWithStylesAndAttributes styles nodeAttrs edgeAttrs graph =
 
         edgesString =
             List.map edge edges
-                |> String.join ";\n"
+                |> String.join "\n"
 
         edge e =
             "  "
@@ -167,7 +167,7 @@ outputWithStylesAndAttributes styles nodeAttrs edgeAttrs graph =
 
         nodesString =
             List.map node nodes
-                |> String.join ";\n"
+                |> String.join "\n"
 
         node n =
             "  "
@@ -176,13 +176,13 @@ outputWithStylesAndAttributes styles nodeAttrs edgeAttrs graph =
     in
     String.join "\n"
         [ "digraph G {"
-        , "  rankdir=" ++ toString styles.rankdir ++ ";"
-        , "  graph [" ++ styles.graph ++ "];"
-        , "  node [" ++ styles.node ++ "];"
-        , "  edge [" ++ styles.edge ++ "];"
+        , "  rankdir=" ++ toString styles.rankdir
+        , "  graph [" ++ styles.graph ++ "]"
+        , "  node [" ++ styles.node ++ "]"
+        , "  edge [" ++ styles.edge ++ "]"
         , ""
-        , edgesString ++ ";"
+        , edgesString
         , ""
-        , nodesString ++ ";"
+        , nodesString
         , "}"
         ]

--- a/tests/Tests/Graph/DOT.elm
+++ b/tests/Tests/Graph/DOT.elm
@@ -34,19 +34,19 @@ all =
 
                     expected =
                         """digraph G {
-  rankdir=TB;
-  graph [];
-  node [];
-  edge [];
+  rankdir=TB
+  graph []
+  node []
+  edge []
 
-  0 -> 1;
-  1 -> 2;
-  1 -> 3;
+  0 -> 1
+  1 -> 2
+  1 -> 3
 
-  0 [label="Welcome"];
-  1 [label="To"];
-  2 [label="Web"];
-  3 [label="\\"GraphViz\\"!"];
+  0 [label="Welcome"]
+  1 [label="To"]
+  2 [label="Web"]
+  3 [label="\\"GraphViz\\"!"]
 }"""
 
                     actual =
@@ -76,19 +76,19 @@ all =
 
                     expected =
                         """digraph G {
-  rankdir=TB;
-  graph [];
-  node [];
-  edge [];
+  rankdir=TB
+  graph []
+  node []
+  edge []
 
-  0 -> 1;
-  1 -> 2 [label="wait for it"];
-  1 -> 3 [label="ok"];
+  0 -> 1
+  1 -> 2 [label="wait for it"]
+  1 -> 3 [label="ok"]
 
-  0 [label="Welcome"];
-  1 [label="To"];
-  2 [label="Web"];
-  3 [label="GraphViz!"];
+  0 [label="Welcome"]
+  1 [label="To"]
+  2 [label="Web"]
+  3 [label="GraphViz!"]
 }"""
 
                     actual =
@@ -118,19 +118,19 @@ all =
 
                     expected =
                         """digraph G {
-  rankdir=LR;
-  graph [bgcolor=red];
-  node [shape=box, color=blue, style="rounded, filled"];
-  edge [];
+  rankdir=LR
+  graph [bgcolor=red]
+  node [shape=box, color=blue, style="rounded, filled"]
+  edge []
 
-  0 -> 1;
-  1 -> 2;
-  1 -> 3;
+  0 -> 1
+  1 -> 2
+  1 -> 3
 
-  0 [label="Welcome"];
-  1 [label="To"];
-  2 [label="Web"];
-  3 [label="GraphViz!"];
+  0 [label="Welcome"]
+  1 [label="To"]
+  2 [label="Web"]
+  3 [label="GraphViz!"]
 }"""
 
                     myStyles =
@@ -191,23 +191,74 @@ all =
 
                     expected =
                         """digraph G {
-  rankdir=TB;
-  graph [];
-  node [style=rounded];
-  edge [];
+  rankdir=TB
+  graph []
+  node [style=rounded]
+  edge []
 
-  0 -> 1;
-  1 -> 2;
-  1 -> 3 [penwidth="5"];
+  0 -> 1
+  1 -> 2
+  1 -> 3 [penwidth="5"]
 
-  0 [label="Welcome"];
-  1 [label="To"];
-  2 [label="Web"];
-  3 [label="GraphViz!", style="bold,filled"];
+  0 [label="Welcome"]
+  1 [label="To"]
+  2 [label="Web"]
+  3 [label="GraphViz!", style="bold,filled"]
 }"""
 
                     actual =
                         outputWithStylesAndAttributes myStyles nodeAttrs edgeAttrs g
+                in
+                \() -> Expect.equal expected actual
+            , test "empty graph" <|
+                let
+                    g =
+                        Graph.empty
+
+                    expected =
+                        """digraph G {
+  rankdir=TB
+  graph []
+  node []
+  edge []
+
+
+
+
+}"""
+
+                    actual =
+                        output Just (always Nothing) g
+                in
+                \() -> Expect.equal expected actual
+            , test "graph with nodes but no edges" <|
+                let
+                    nodes =
+                        [ Node 0 "Hello"
+                        , Node 1 "Bye"
+                        ]
+
+                    edges =
+                        []
+
+                    g =
+                        Graph.fromNodesAndEdges nodes edges
+
+                    expected =
+                        """digraph G {
+  rankdir=TB
+  graph []
+  node []
+  edge []
+
+
+
+  0 [label="Hello"]
+  1 [label="Bye"]
+}"""
+
+                    actual =
+                        output Just (always Nothing) g
                 in
                 \() -> Expect.equal expected actual
             ]


### PR DESCRIPTION
Hello @sgraf812 
I've started using graphviz export in my simple [graph editor](http://janhrcek.cz/graph-editor) but now I noticed that it generates invalid graphviz output in case that graph is empty / has no edges.

Here's the output `Graph.DOT.output Just (always Nothing) Graph.empty`
```
digraph G {
  rankdir=TB;
  graph [];
  node [];
  edge [];

;

;
}
```
The extraneous `;` are causing graphviz tools to fail with `syntax error in line 7 near ';'\n`

The proposed fix in the PR removes the extraneous `;`, but (to keep the implementation simple) also removes empty newlines between attributes / edges / nodes section. Also adding two test cases for the problematic cases. Feel free to implement it differently (anything if the generated output is valid input for valid tools).