### PR TITLE
Fix #18 dfsTree does not preserve contexts of the original graph

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -18,6 +18,6 @@
         "elm-community/intdict": "3.0.0 <= v < 4.0.0"
     },
     "test-dependencies": {
-        "elm-explorations/test": "1.0.0 <= v < 2.0.0"
+        "elm-explorations/test": "2.0.0 <= v < 3.0.0"
     }
 }

--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "elm-community/graph",
     "summary": "Handling graphs the functional way.",
     "license": "MIT",
-    "version": "6.0.0",
+    "version": "6.0.1",
     "exposed-modules": [
         "Graph",
         "Graph.Tree",

--- a/src/Graph.elm
+++ b/src/Graph.elm
@@ -87,10 +87,11 @@ representation.
 -}
 
 import Debug
-import Fifo as Fifo exposing (Fifo)
+import Fifo exposing (Fifo)
 import Graph.Tree as Tree exposing (Forest, Tree)
-import IntDict as IntDict exposing (IntDict)
-import Maybe as Maybe exposing (Maybe)
+import IntDict exposing (IntDict)
+import Maybe exposing (Maybe)
+import Set exposing (Set)
 
 
 {-| The type used for identifying nodes, an integer.
@@ -646,7 +647,7 @@ The following is a specification for reverseEdges:
 
 Info: Make sure you are applying changes both to `incoming` and `outgoing`.
 The `Graph` data structure has inherent redundancy -- every edge in the incoming `IntDict` for a given node shows up again in the outgoing `IntDict` for the node on the other end of the edge and vice-versa.
-So you can use mapContexts  to modify graphs, but you have to make consistent edge changes between each pair of nodes during the mapping.
+So you can use mapContexts to modify graphs, but you have to make consistent edge changes between each pair of nodes during the mapping.
 Otherwise you'll get order-dependent results.
 This may not be the ideal way to "rewire" a graph.
 
@@ -960,34 +961,42 @@ guidedDfs :
     -> ( acc, Graph n e )
 guidedDfs selectNeighbors visitNode startingSeeds startingAcc startingGraph =
     let
-        go seeds acc graph =
+        go : List NodeId -> Set NodeId -> acc -> Graph n e -> ( acc, Set NodeId, Graph n e )
+        go seeds visited acc graph =
             case seeds of
                 [] ->
                     -- We are done with this connected component, so we return acc and the rest of the graph
-                    ( acc, graph )
+                    ( acc, visited, graph )
 
                 next :: seeds1 ->
-                    case get next graph of
-                        -- This can actually happen since we don't filter for already visited nodes.
-                        -- That would be an opportunity for time-memory-tradeoff.
-                        -- E.g. Passing along a set of visited nodeIds.
-                        Nothing ->
-                            go seeds1 acc graph
+                    if Set.member next visited then
+                        go seeds1 visited acc graph
 
-                        Just ctx ->
-                            let
-                                ( accAfterDiscovery, finishNode ) =
-                                    visitNode ctx acc
+                    else
+                        case get next graph of
+                            -- This can actually happen since we don't filter for already visited nodes.
+                            -- That would be an opportunity for time-memory-tradeoff.
+                            -- E.g. Passing along a set of visited nodeIds.
+                            Nothing ->
+                                go seeds1 (Set.insert next visited) acc graph
 
-                                ( accBeforeFinish, graph1 ) =
-                                    go (selectNeighbors ctx) accAfterDiscovery (remove next graph)
+                            Just ctx ->
+                                let
+                                    ( accAfterDiscovery, finishNode ) =
+                                        visitNode ctx acc
 
-                                accAfterFinish =
-                                    finishNode accBeforeFinish
-                            in
-                            go seeds1 accAfterFinish graph1
+                                    ( accBeforeFinish, visited1, graph1 ) =
+                                        go (selectNeighbors ctx) (Set.insert next visited) accAfterDiscovery graph
+
+                                    accAfterFinish =
+                                        finishNode accBeforeFinish
+                                in
+                                go seeds1 visited1 accAfterFinish graph1
+
+        ( finalAcc, _, finalGraph ) =
+            go startingSeeds Set.empty startingAcc startingGraph
     in
-    go startingSeeds startingAcc startingGraph
+    ( finalAcc, finalGraph )
 
 
 {-| An off-the-shelf depth-first traversal. It will visit all components of the

--- a/tests/Tests/Graph.elm
+++ b/tests/Tests/Graph.elm
@@ -174,7 +174,8 @@ expectTopologicalOrderingOf graph ordering =
                 , "    " ++ Debug.toString ordering
                 ]
     in
-    Expect.true message (isValidTopologicalOrderingOf graph ordering)
+    Expect.equal True (isValidTopologicalOrderingOf graph ordering)
+        |> Expect.onFail message
 
 
 all : Test
@@ -391,8 +392,7 @@ all =
             describe "Graph ops"
                 [ test "symmetricClosure is symmetric" <|
                     \() ->
-                        Expect.true
-                            "expected all incoming edges to also be outgoing and vice versa"
+                        Expect.equal True
                             (dressUp
                                 |> Graph.symmetricClosure (\_ _ e _ -> e)
                                 |> Graph.fold
@@ -401,6 +401,7 @@ all =
                                     )
                                     True
                             )
+                            |> Expect.onFail "expected all incoming edges to also be outgoing and vice versa"
                 , test "reverseEdges" <|
                     \() ->
                         Expect.equal
@@ -421,19 +422,19 @@ all =
             describe "checkAcyclicTests" <|
                 [ test "Ok for graph with no cycles" <|
                     \() ->
-                        Expect.true
-                            "Should return Ok"
+                        Expect.equal True
                             (isOk (Graph.checkAcyclic dressUp))
+                            |> Expect.onFail "Should return Ok"
                 , test "Err for cyclic graph" <|
                     \() ->
-                        Expect.true
-                            "Should return Err"
+                        Expect.equal True
                             (isErr (Graph.checkAcyclic dressUpWithCycle))
+                            |> Expect.onFail "Should return Err"
                 , test "Err for connectedComponents" <|
                     \() ->
-                        Expect.true
-                            "Should return Err"
+                        Expect.equal True
                             (isErr (Graph.checkAcyclic connectedComponents))
+                            |> Expect.onFail "Should return Err"
                 ]
 
         topologicalSortTests =
@@ -492,9 +493,9 @@ all =
             describe "Strongly connected components"
                 [ test "The input graph was acyclic" <|
                     \() ->
-                        Expect.true
-                            "Result should be Err"
+                        Expect.equal True
                             (isErr result)
+                            |> Expect.onFail "Result should be Err"
                 , test "The expected SCCs in order" <|
                     \() ->
                         Expect.equal
@@ -513,14 +514,14 @@ all =
                             )
                 , test "dressUp is acyclic" <|
                     \() ->
-                        Expect.true
-                            "Should be Ok"
+                        Expect.equal True
                             (isOk (Graph.stronglyConnectedComponents dressUp))
+                            |>Expect.onFail "Should be Ok"
                 , test "The input graph has loops" <|
                     \() ->
-                        Expect.true
-                            "Should be Err"
+                        Expect.equal True
                             (isErr (Graph.stronglyConnectedComponents graphWithLoop))
+                            |>Expect.onFail "Should be Err"
                 ]
 
         unitTests =
@@ -554,13 +555,13 @@ all =
                             iWantToWearShoes
                 , test "insert" <|
                     \() ->
-                        Expect.true "Graph size wasn't 2" insertExample
+                        Expect.equal True insertExample |> Expect.onFail "Graph size wasn't 2"
                 , test "fold" <|
                     \() ->
-                        Expect.true "The graph had a loop." foldExample
+                        Expect.equal True foldExample |> Expect.onFail "The graph had a loop."
                 , test "mapContexts" <|
                     \() ->
-                        Expect.true "Mapped edge flip should've reversed edges" mapContextsExample
+                        Expect.equal True mapContextsExample |> Expect.onFail "Mapped edge flip should've reversed edges"
                 ]
     in
     describe "The Graph module"

--- a/tests/Tests/Graph.elm
+++ b/tests/Tests/Graph.elm
@@ -516,12 +516,78 @@ all =
                     \() ->
                         Expect.equal True
                             (isOk (Graph.stronglyConnectedComponents dressUp))
-                            |>Expect.onFail "Should be Ok"
+                            |> Expect.onFail "Should be Ok"
                 , test "The input graph has loops" <|
                     \() ->
                         Expect.equal True
                             (isErr (Graph.stronglyConnectedComponents graphWithLoop))
-                            |>Expect.onFail "Should be Err"
+                            |> Expect.onFail "Should be Err"
+                ]
+
+        dfsTests =
+            describe "DFS traversal"
+                [ test "depth-first node order on discovery" <|
+                    \() ->
+                        Expect.equal
+                            [ 0, 3, 1, 2, 6, 8, 4, 5, 7 ]
+                            (dressUp
+                                |> Graph.dfs (Graph.onDiscovery (::)) []
+                                |> List.map (.node >> .id)
+                                |> List.reverse
+                            )
+                , test "depth-first node order on finish" <|
+                    \() ->
+                        Expect.equal
+                            [ 3, 0, 8, 6, 2, 1, 4, 7, 5 ]
+                            (dressUp
+                                |> Graph.dfs (Graph.onFinish (::)) []
+                                |> List.map (.node >> .id)
+                                |> List.reverse
+                            )
+                , test "access to incoming context" <|
+                    \() ->
+                        let
+                            incoming =
+                                Graph.fold (\ctx acc ->
+                                   (ctx.node.id, IntDict.keys ctx.incoming)
+                                   :: acc
+                                )
+                                []
+                                dressUp
+                                |> List.sortBy Tuple.first
+                        in
+                        Expect.equal
+                            incoming
+                            (dressUp
+                                |> Graph.dfs (Graph.onDiscovery (::)) []
+                                |> List.map
+                                    (\ctx ->
+                                        ( ctx.node.id, IntDict.keys ctx.incoming )
+                                    )
+                                |> List.sortBy Tuple.first
+                            )
+                , test "access to outgoing context" <|
+                    \() ->
+                        let
+                            outgoing =
+                                Graph.fold (\ctx acc ->
+                                   (ctx.node.id, IntDict.keys ctx.outgoing)
+                                   :: acc
+                                )
+                                []
+                                dressUp
+                                |> List.sortBy Tuple.first
+                        in
+                        Expect.equal
+                            outgoing
+                            (dressUp
+                                |> Graph.dfs (Graph.onDiscovery (::)) []
+                                |> List.map
+                                    (\ctx ->
+                                        ( ctx.node.id, IntDict.keys ctx.outgoing )
+                                    )
+                                |> List.sortBy Tuple.first
+                            )
                 ]
 
         unitTests =
@@ -544,6 +610,7 @@ all =
                 , topologicalSortTests
                 , bfsTests
                 , sccTests
+                , dfsTests
                 ]
 
         examples =

--- a/tests/Tests/Graph/Tree.elm
+++ b/tests/Tests/Graph/Tree.elm
@@ -82,7 +82,7 @@ all =
                     Tree.inner 10 [ Tree.leaf 20, Tree.leaf 30, Tree.leaf 40, Tree.empty ]
             in
             describe "map"
-                [ test "does not change empty" <| \() -> Expect.true "empty remains empty" <| Tree.isEmpty <| Tree.map identity Tree.empty
+                [ test "does not change empty" <| \() -> Expect.onFail "empty remains empty" <| Expect.equal True <| Tree.isEmpty <| Tree.map identity Tree.empty
                 , test "does not change structure of a tree" <| \() -> Expect.equal sample <| Tree.map identity sample
                 , test "applies function to all nodes" <| \() -> Expect.equal samplePlusOne <| Tree.map (\x -> x * 10) sample
                 ]


### PR DESCRIPTION
Fixes #18 
Solution uses a set of visited nodes instead of removing the currently visited node from the graph.
Root cause: when removing a node from a graph it's incoming and outgoing edges are also removed, modifying the context provided to the visitor function.