### PR TITLE
Fix #18 dfsTree does not preserve contexts of the original graph

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "elm-community/graph",
     "summary": "Handling graphs the functional way.",
     "license": "MIT",
-    "version": "6.0.1",
+    "version": "7.0.0",
     "exposed-modules": [
         "Graph",
         "Graph.Tree",

--- a/tests/Tests/Graph.elm
+++ b/tests/Tests/Graph.elm
@@ -517,6 +517,74 @@ all =
                             (Graph.stronglyConnectedComponents graphWithLoop)
                 ]
 
+        dfsTests =
+            describe "DFS traversal"
+                [ test "depth-first node order on discovery" <|
+                    \() ->
+                        Expect.equal
+                            [ 0, 3, 1, 2, 6, 8, 4, 5, 7 ]
+                            (dressUp
+                                |> Graph.dfs (Graph.onDiscovery (::)) []
+                                |> List.map (.node >> .id)
+                                |> List.reverse
+                            )
+                , test "depth-first node order on finish" <|
+                    \() ->
+                        Expect.equal
+                            [ 3, 0, 8, 6, 2, 1, 4, 7, 5 ]
+                            (dressUp
+                                |> Graph.dfs (Graph.onFinish (::)) []
+                                |> List.map (.node >> .id)
+                                |> List.reverse
+                            )
+                , test "access to incoming context" <|
+                    \() ->
+                        let
+                            incoming =
+                                Graph.fold
+                                    (\ctx acc ->
+                                        ( ctx.node.id, IntDict.keys ctx.incoming )
+                                            :: acc
+                                    )
+                                    []
+                                    dressUp
+                                    |> List.sortBy Tuple.first
+                        in
+                        Expect.equal
+                            incoming
+                            (dressUp
+                                |> Graph.dfs (Graph.onDiscovery (::)) []
+                                |> List.map
+                                    (\ctx ->
+                                        ( ctx.node.id, IntDict.keys ctx.incoming )
+                                    )
+                                |> List.sortBy Tuple.first
+                            )
+                , test "access to outgoing context" <|
+                    \() ->
+                        let
+                            outgoing =
+                                Graph.fold
+                                    (\ctx acc ->
+                                        ( ctx.node.id, IntDict.keys ctx.outgoing )
+                                            :: acc
+                                    )
+                                    []
+                                    dressUp
+                                    |> List.sortBy Tuple.first
+                        in
+                        Expect.equal
+                            outgoing
+                            (dressUp
+                                |> Graph.dfs (Graph.onDiscovery (::)) []
+                                |> List.map
+                                    (\ctx ->
+                                        ( ctx.node.id, IntDict.keys ctx.outgoing )
+                                    )
+                                |> List.sortBy Tuple.first
+                            )
+                ]
+
         unitTests =
             describe "unit tests"
                 [ emptyTests
@@ -538,6 +606,7 @@ all =
                 , topologicalSortTests
                 , bfsTests
                 , sccTests
+                , dfsTests
                 ]
 
         examples =
@@ -666,13 +735,11 @@ symmetricClosureExample =
         == True
 
 
-onDiscoveryExample : ()
-
-
 
 -- Just let it compile
 
 
+onDiscoveryExample : ()
 onDiscoveryExample =
     let
         dfsPostOrder : Graph n e -> List (NodeContext n e)
@@ -682,13 +749,11 @@ onDiscoveryExample =
     dfsPostOrder Graph.empty |> (\_ -> ())
 
 
-onFinishExample : ()
-
-
 
 -- Just let it compile
 
 
+onFinishExample : ()
 onFinishExample =
     let
         dfsPreOrder : Graph n e -> List (NodeContext n e)
@@ -698,13 +763,11 @@ onFinishExample =
     dfsPreOrder Graph.empty |> (\_ -> ())
 
 
-ignorePathExample : ()
-
-
 
 -- Just let it compile
 
 
+ignorePathExample : ()
 ignorePathExample =
     let
         bfsLevelOrder : Graph n e -> List (NodeContext n e)


### PR DESCRIPTION
Fix #18 

This PR is based on PR #30, which has been inactive for 8 months now with the last commit being almost a year ago.

I rebased the commits from that PR and applied the changes proposed by @sgraf812 ([this](https://github.com/elm-community/graph/pull/30#discussion_r1339677121) and [this](https://github.com/elm-community/graph/pull/30#discussion_r1339677936) comments)

Note that the change in `gudedDfs` function signature meant that this is a breaking change, so I bumped the major version as well.